### PR TITLE
Adding command line parsing for endpoint files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ TAGS
 .emacs.desktop.lock
 *.test
 *.sw[nop]
+*~

--- a/apiserver/client/virtual.go
+++ b/apiserver/client/virtual.go
@@ -79,7 +79,7 @@ func setVirtualServiceSettings(st *state.State, serviceName string, endpoints []
 	for _, ep := range endpoints {
 		key := strings.Join([]string{"s", serviceName, ep.Relation, ep.Interface}, "#")
 		logger.Debugf("serviceKey: %q", key)
-		state.WriteVirtualSettings(st, key, ep.Payload)
+		state.WriteVirtualSettings(st, key, ep.Values)
 	}
 	return nil
 }

--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -185,7 +185,19 @@ type DestroyMachines struct {
 type VirtualEndpoint struct {
 	Relation  string
 	Interface string
-	Payload   map[string]interface{}
+	Values    map[string]interface{}
+}
+
+// The VirtualEndpointConfig is a data structure to use to when reading
+// in the JSON or YAML file that contains virtual endpoint definition.
+// Example:
+// {"endpoints":[{"relation":"website","interface":"http","values":{"hostname":"10.0.3.1"},{"port":"6543"},{"private-address" :"10.0.3.1"}}]}
+type VirtualEndpointConfig struct {
+	Endpoints []struct {
+		Relation  string                   `json:"relation" yaml:"relation"`
+		Interface string                   `json:"interface" yaml:"interface"`
+		Values    map[string]interface{}   `json:"values" yaml:"values"`
+	} `json:"endpoints" yaml:"endpoints"`
 }
 
 // VirtualServiceDeploy

--- a/cmd/juju/deploy.go
+++ b/cmd/juju/deploy.go
@@ -217,13 +217,7 @@ func (c *DeployCommand) Run(ctx *cmd.Context) error {
 	}
 
 	if c.CharmRef.Schema == "virtual" {
-		if c.VirtualEndpoints != "" {
-			virtualEndpoint := parseVirtualEndpoints(c.virtualEndpoints)
-			err := addVirtualServiceViaAPI(client, c.CharmRef, c.VirtualEndpoints)
-		}
-		if c.VirtualEndpointsFile != "" {
-			err := 1
-		}
+		err = c.deployVirtualEndpoints(client)
 		return block.ProcessBlockedError(err, block.BlockChange)
 	}
 
@@ -316,6 +310,17 @@ func (c *DeployCommand) Run(ctx *cmd.Context) error {
 			c.ToMachineSpec)
 	}
 	return block.ProcessBlockedError(err, block.BlockChange)
+}
+
+// deployVirtualEndpoints
+func (c *DeployCommand) deployVirtualEndpoints(client *api.Client) error {
+	if c.VirtualEndpoints != "" {
+		virtualEndpoint := parseVirtualEndpoints(c.virtualEndpoints)
+		err := addVirtualServiceViaAPI(client, c.CharmRef, c.VirtualEndpoints)
+	}
+	if c.VirtualEndpointsFile != "" {
+		err := 1
+	}
 }
 
 // addVirtualServiceViaAPI

--- a/cmd/juju/deploy.go
+++ b/cmd/juju/deploy.go
@@ -319,7 +319,7 @@ func (c *DeployCommand) deployVirtualEndpoints(client *api.Client) error {
 	if c.VirtualEndpoints != "" {
 		commandlineEndpoints, err := parseVirtualEndpoints(c.VirtualEndpoints)
 		if err != nil {
-			return nil, err
+			return err
 		}
 		append(virtualEndpoints, commandlineEndpoints)
 	}
@@ -327,7 +327,7 @@ func (c *DeployCommand) deployVirtualEndpoints(client *api.Client) error {
 	if c.VirtualEndpointsFile != "" {
 		fileEndpoints, err := parseVirtualEndpointsFile(c.VirtualEndpointsFile)
 		if err != nil {
-			return nil, err
+			return err
 		}
 		append(virtualEndpoints, fileEndpoints)
 	}
@@ -425,6 +425,7 @@ func parseVirtualEndpointsFile(filepath string) ([]params.VirtualEndpoint, error
 		return nil, errors.New("unsupported endpoint file type")
 	}
 }
+
 // parseVirtualEndpointJSONFile read a json file, emit virtual endpoints.
 // example:
 // juju deploy virtual:name service-name --endpoints-file=endpoint.json

--- a/cmd/juju/deploy.go
+++ b/cmd/juju/deploy.go
@@ -48,7 +48,7 @@ type DeployCommand struct {
 	Storage map[string]storage.Constraints
 
 	// VirtualEndpoints
-	VirtualEndpoints string
+	VirtualEndpoints     string
 	VirtualEndpointsFile string
 }
 
@@ -168,7 +168,7 @@ func (c *DeployCommand) Init(args []string) error {
 		if err != nil {
 			return err
 		}
-    isVirtual := c.CharmRef.Schema == "virtual"
+		isVirtual := c.CharmRef.Schema == "virtual"
 		if isVirtual {
 			fmt.Printf("c.VirtualEndpoint = %q\n", c.VirtualEndpoints)
 			if c.VirtualEndpoints == "" && c.VirtualEndpointsFile == "" {
@@ -179,7 +179,7 @@ func (c *DeployCommand) Init(args []string) error {
 			}
 		}
 
-    if c.VirtualEndpoints != "" && !isVirtual {
+		if c.VirtualEndpoints != "" && !isVirtual {
 			return fmt.Errorf("using --endpoints requires the virtual charm type")
 		}
 		if c.VirtualEndpointsFile == "" && !isVirtual {
@@ -191,7 +191,7 @@ func (c *DeployCommand) Init(args []string) error {
 				return fmt.Errorf("invalid charm name %q", args[0])
 			}
 		}
-		c.CharmName = args[0]s
+		c.CharmName = args[0]
 	case 0:
 		return errors.New("no charm specified")
 	default:
@@ -217,14 +217,12 @@ func (c *DeployCommand) Run(ctx *cmd.Context) error {
 	}
 
 	if c.CharmRef.Schema == "virtual" {
-
 		if c.VirtualEndpoints != "" {
-			virtualEndpoint parseVirtualEndpoints(c.virtualEndpoints)
+			virtualEndpoint := parseVirtualEndpoints(c.virtualEndpoints)
 			err := addVirtualServiceViaAPI(client, c.CharmRef, c.VirtualEndpoints)
 		}
 		if c.VirtualEndpointsFile != "" {
-
-			err :=
+			err := 1
 		}
 		return block.ProcessBlockedError(err, block.BlockChange)
 	}
@@ -413,7 +411,7 @@ func getEndpoints(endpointsArg string, endpointsFile string) ([]string, error) {
 			return nil, err
 		}
 		virtEndpoints := []params.VirtualEndpoint{endpoint}
-	} else if endpointsFile != "" {}
+	} else if endpointsFile != "" {
 		endpointStrings, err := readEndpointsFile(endpointFile)
 		for _, data := range endpointStrings {
 			endpoint, err := parseVirtualEndpoint()
@@ -423,10 +421,42 @@ func getEndpoints(endpointsArg string, endpointsFile string) ([]string, error) {
 		}
 	}
 
-	return []params.VirtualEndpoint{endpoint}
+	return []params.VirtualEndpoint{endpoint}, nil
 }
+
+// parseVirtualEndpointJSONFile
+// Parse a json file for virtual endpoint data
+// ex:
+// --endpoints-file=wat.json
+// {"endpoints":["db:wat":{},
+//	         "db:hey":{}]}
+func parseVirtualEndpointJSONFile(filepath string) ([]params.VirtualEndpoint, error) {
+
+}
+
+// parseVirtualEndpointYAMLFile
+// Parse a yaml file for virtual endpoint data
+// ex:
+// --endpoints-file=wat.yaml
+// endpoints:
+//  - 'db:wat':{}
+//  - 'db:hey':{}
+func parseVirtualEndpointYAMLFile(filepath string) ([]params.VirtualEndpoint, error) {
+
+}
+
+// parseVirtualEndpoints
+// Parse json embedded command line for virtual endpoint data
+// ex:
+// --endpoints=db:wat='{}',db:yeah='{}'
+//
+func parseVirtualEndpoints(input string) ([]params.VirtualEndpoint, error) {
+
+}
+
 // parseVirtualEndpoint takes a single endpoint string and parses out the relation, interface and JSON data.
 // Expected format:  relation:interface=JSON
+// example: db:wat='{}'
 func parseVirtualEndpoint(data string) (VirtualEndpoint, error) {
 	var virtEndpoint params.VirtualEndpoint
 

--- a/cmd/juju/deploy.go
+++ b/cmd/juju/deploy.go
@@ -320,9 +320,7 @@ func (c *DeployCommand) deployVirtualEndpoints(client *api.Client) error {
 		if err != nil {
 			return err
 		}
-		for _, endpoint := range commandlineEndpoints {
-			virtualEndpoints = append(virtualEndpoints, endpoint)
-		}
+		virtualEndpoints = append(virtualEndpoints, commandlineEndpoints...)
 	}
 	// Add the virtual endpoints defined from the endpoints file.
 	if c.VirtualEndpointsFile != "" {
@@ -330,9 +328,7 @@ func (c *DeployCommand) deployVirtualEndpoints(client *api.Client) error {
 		if err != nil {
 			return err
 		}
-		for _, endpoint := range fileEndpoints {
-			virtualEndpoints = append(virtualEndpoints, endpoint)
-		}
+		virtualEndpoints = append(virtualEndpoints, fileEndpoints...)
 	}
 	// Add the virtual servcie via the API.
 	if err := client.VirtualServiceDeploy(c.CharmRef.Name, virtualEndpoints); err != nil {

--- a/cmd/juju/deploy.go
+++ b/cmd/juju/deploy.go
@@ -170,7 +170,6 @@ func (c *DeployCommand) Init(args []string) error {
 		}
 		isVirtual := c.CharmRef.Schema == "virtual"
 		if isVirtual {
-			fmt.Printf("c.VirtualEndpoint = %q\n", c.VirtualEndpoints)
 			if c.VirtualEndpoints == "" && c.VirtualEndpointsFile == "" {
 				return fmt.Errorf("virtual charm type requires either --endpoints or --endpoints-file")
 			}


### PR DESCRIPTION
The way the current code handles an endpoint file is it handles 1 definition in the file.  This fix changes the virtual services command-line parsing to accept the `--endpoints` or `--endpoints-file` flags.

Example usage of the `--endpoints` flag:

    juju deploy virtual:matt --endpoints='db:mysql={"database":"juju", "user": "root", "password": "root", "private-address": "172.17.42.1"}'

Examples usage of the `--endpoints-file` flag:

    juju deploy virtual:matt2 --endpoints-file=/tmp/matt.json
    juju deploy virtual:matt3 --endpoints-file=/tmp/matt.yaml

Where `matt.json` is:
```
{
  "endpoints":[
    {
      "relation":"website",
      "interface":"http",
      "values": {
        "hostname":"10.0.3.1",
        "port":"6543",
        "private-address" :"10.0.3.1"
      }
    }
  ]
}
```
and `matt.yaml` is:
```
endpoints:
- interface: http
  relation: website
  values:
    hostname: 10.0.3.1
    port: '6543'
    private-address: 10.0.3.1
```